### PR TITLE
Update SamlExtension.php

### DIFF
--- a/src/DI/SamlExtension.php
+++ b/src/DI/SamlExtension.php
@@ -20,6 +20,7 @@ class SamlExtension extends CompilerExtension
             'url_idp_sign_in' => Expect::string()->required()->dynamic(),
             'url_idp_sign_out' => Expect::string()->required()->dynamic(),
             'backlink' => Expect::string()->required(),
+            'saml_force_http' => Expect::bool()->default(false),
         ]);
     }
 


### PR DESCRIPTION
This fix adds option saml_force_http (bool) used for rewrite the generated url scheme from https to http. Use case is local development in docker.